### PR TITLE
Adding missing semicolon

### DIFF
--- a/src/ESPHue.cpp
+++ b/src/ESPHue.cpp
@@ -151,7 +151,7 @@ String ESPHue::getGroupInfo(byte groupNum)
                "Host: " + _host + "\r\n" +
                "Connection: keep-alive\r\n\r\n");
   String line;
-	delay(200)
+	delay(200);
   while(_client->available()){
     line = _client->readString();
   }


### PR DESCRIPTION
Missing semicolon after a delay was causing compile error.